### PR TITLE
End active commute in details view

### DIFF
--- a/CommuteLog/AppManager.swift
+++ b/CommuteLog/AppManager.swift
@@ -69,6 +69,7 @@ extension AppManager: CommuteDelegate {
 extension AppManager: CommutesViewControllerEventHandler {
     func commutesViewController(_ vc: CommutesViewController, didSelect commute: Commute) {
         let details = CommuteDetailsViewController(commute: commute, locationStore: locationWrangler.store)
+        details.eventHandler = self
         nav.pushViewController(details, animated: true)
     }
 
@@ -87,6 +88,13 @@ extension AppManager: CommutesViewControllerEventHandler {
 
     func endCommute(for vc: CommutesViewController) {
         commuteManager.endCommute(save: true)
+    }
+}
+
+extension AppManager: CommuteDetailsViewControllerEventHandler {
+    func endCommute(for vc: CommuteDetailsViewController) {
+        commuteManager.endCommute(save: true)
+        vc.commute.end = Date()
     }
 }
 

--- a/CommuteLog/CommuteDetailsViewController.swift
+++ b/CommuteLog/CommuteDetailsViewController.swift
@@ -40,9 +40,6 @@ class CommuteDetailsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-
         view.backgroundColor = .white
 
         updateLabels()
@@ -65,8 +62,6 @@ class CommuteDetailsViewController: UIViewController {
         mapView.translatesAutoresizingMaskIntoConstraints = false
         mapView.showsUserLocation = true
         mapView.delegate = self
-        formatter.timeStyle = .long
-        formatter.dateStyle = .none
 
         [commute.startPoint, commute.endPoint].forEach(addAnnotation(for:))
         locations = locationStore.locations(for: commute)
@@ -101,7 +96,7 @@ class CommuteDetailsViewController: UIViewController {
     private func addAnnotation(for location: Location) {
         let annotation = MKPointAnnotation()
         annotation.coordinate = location.clCoordinate
-        annotation.title = formatter.string(from: location.timestamp)
+        annotation.title = annotationStyleString(from: location.timestamp)
         mapView.addAnnotation(annotation)
     }
 
@@ -118,11 +113,11 @@ class CommuteDetailsViewController: UIViewController {
     }
 
     private func updateLabels() {
-        startLabel.text = "Start: \(formatter.string(from: commute.start))"
+        startLabel.text = "Start: \(labelStyleString(from: commute.start))"
 
         let endText: String
         if let end = commute.end {
-            endText = formatter.string(from: end)
+            endText = labelStyleString(from: end)
         } else {
             endText = "---"
         }
@@ -176,5 +171,32 @@ extension CommuteDetailsViewController: MKMapViewDelegate {
         } else {
             return MKPolylineRenderer()
         }
+    }
+}
+
+extension CommuteDetailsViewController {
+    func annotationStyleString(from date: Date) -> String {
+        let originalTimeStyle = formatter.timeStyle
+        let originalDateStyle = formatter.dateStyle
+        formatter.timeStyle = .long
+        formatter.dateStyle = .none
+        defer {
+            formatter.timeStyle = originalTimeStyle
+            formatter.dateStyle = originalDateStyle
+        }
+        return formatter.string(from: date)
+    }
+
+    func labelStyleString(from date: Date) -> String {
+        let originalTimeStyle = formatter.timeStyle
+        let originalDateStyle = formatter.dateStyle
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        defer {
+            formatter.timeStyle = originalTimeStyle
+            formatter.dateStyle = originalDateStyle
+        }
+
+        return formatter.string(from: date)
     }
 }

--- a/CommuteLog/CommuteDetailsViewController.swift
+++ b/CommuteLog/CommuteDetailsViewController.swift
@@ -9,9 +9,14 @@
 import UIKit
 import MapKit
 
+protocol CommuteDetailsViewControllerEventHandler: class {
+    func endCommute(for vc: CommuteDetailsViewController)
+}
+
 class CommuteDetailsViewController: UIViewController {
     let mapView = MKMapView(frame: .zero)
     let formatter: DateFormatter = DateFormatter()
+    weak var eventHandler: CommuteDetailsViewControllerEventHandler?
 
     private(set) var commute: Commute
     private let locationStore: LocationStore
@@ -41,6 +46,7 @@ class CommuteDetailsViewController: UIViewController {
         view.backgroundColor = .white
 
         updateLabels()
+        updateNavButton()
         let labels = UIStackView(arrangedSubviews: [startLabel, endLabel])
         labels.alignment = .fill
         labels.axis = .vertical
@@ -89,6 +95,7 @@ class CommuteDetailsViewController: UIViewController {
         commute = newCommute
 
         updateLabels()
+        updateNavButton()
     }
 
     private func addAnnotation(for location: Location) {
@@ -120,6 +127,20 @@ class CommuteDetailsViewController: UIViewController {
             endText = "---"
         }
         endLabel.text = "End:   \(endText)"
+    }
+
+    private func updateNavButton() {
+        if commute.isActive {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(title: "End", style: .plain, target: self, action: #selector(endCommute))
+        } else {
+            navigationItem.rightBarButtonItem = nil
+        }
+    }
+
+    @objc private func endCommute() {
+        eventHandler?.endCommute(for: self)
+        updateNavButton()
+        updateLabels()
     }
 }
 


### PR DESCRIPTION
End the active commute from the details screen.
Resolves #11 and I believe fixes #5 as well
Also refactors the label/annotation formatting a bit as once the end time was updating after `viewDidLoad()`  the start and end labels were showing up with the formatting of the annotations