### PR TITLE
Fix commute sort order on update

### DIFF
--- a/CommuteLog/CommuteManager.swift
+++ b/CommuteLog/CommuteManager.swift
@@ -100,7 +100,7 @@ class CommuteManager: NSObject {
     }
 
     func fetchCommutes() -> [Commute] {
-        return store.loadCommutes().values.sorted(by: { $0.start < $1.start })
+        return store.loadCommutes().values.sorted(by: { $0.start > $1.start })
     }
 }
 


### PR DESCRIPTION
@aranasaurus Hey sorry, I jumped the gun on #16. The commutes go out of order whenever they're updated. This should fix that