### PR TITLE
Group commutes by morning/evening

### DIFF
--- a/CommuteLog.xcodeproj/project.pbxproj
+++ b/CommuteLog.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DDDF8BC42194E1A8008E8EBF /* Table+Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDF8BC32194E1A8008E8EBF /* Table+Section.swift */; };
 		F90062F42146269600036AFF /* CommuteEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90062F32146269600036AFF /* CommuteEndpoint.swift */; };
 		F90062F6214626CF00036AFF /* CommuteSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90062F5214626CF00036AFF /* CommuteSchedule.swift */; };
 		F906A23521474702007097F5 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F906A23421474702007097F5 /* Logger.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		DDDF8BC32194E1A8008E8EBF /* Table+Section.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Table+Section.swift"; sourceTree = "<group>"; };
 		F90062F32146269600036AFF /* CommuteEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommuteEndpoint.swift; sourceTree = "<group>"; };
 		F90062F5214626CF00036AFF /* CommuteSchedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommuteSchedule.swift; sourceTree = "<group>"; };
 		F906A23421474702007097F5 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 				F98F76CF2129B656000AFF7B /* CommuteManager.swift */,
 				F98F768221292178000AFF7B /* CommutesViewController.swift */,
 				F9A5ED50213F6224006F8681 /* CommuteDetailsViewController.swift */,
+				DDDF8BC32194E1A8008E8EBF /* Table+Section.swift */,
 				F98F76872129217B000AFF7B /* Assets.xcassets */,
 				F98F76892129217B000AFF7B /* LaunchScreen.storyboard */,
 				F98F768C2129217B000AFF7B /* Info.plist */,
@@ -269,6 +272,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDDF8BC42194E1A8008E8EBF /* Table+Section.swift in Sources */,
 				F98F76D02129B656000AFF7B /* CommuteManager.swift in Sources */,
 				F906A23521474702007097F5 /* Logger.swift in Sources */,
 				F90062F6214626CF00036AFF /* CommuteSchedule.swift in Sources */,

--- a/CommuteLog/AppManager.swift
+++ b/CommuteLog/AppManager.swift
@@ -43,24 +43,33 @@ class AppManager: NSObject {
         window.rootViewController = nav
         window.makeKeyAndVisible()
 
-        commuteViewController.commutes = commuteManager.fetchCommutes()
+        updateCommutes()
         commuteViewController.eventHandler = self
 
         if let _ = commuteManager.activeCommute {
             locationWrangler.startTracking()
         }
     }
+
+    func updateCommutes() {
+        commuteViewController.updateTable(
+            Table(
+                Section("To Work") { commuteManager.fetchCommutes(for: CommuteSchedule(hours: 0..<12)) },
+                Section("Home") { commuteManager.fetchCommutes(for: CommuteSchedule(hours: 12..<24)) }
+            )
+        )
+    }
 }
 
 extension AppManager: CommuteDelegate {
     func commuteManager(_ manager: CommuteManager, startedCommute: Commute) {
-        commuteViewController.commutes = manager.fetchCommutes()
+        updateCommutes()
         Logger.debug("Starting location tracking for commute.")
         locationWrangler.startTracking()
     }
 
     func commuteManager(_ manager: CommuteManager, endedCommute: Commute) {
-        commuteViewController.commutes = manager.fetchCommutes()
+        updateCommutes()
         Logger.debug("Stopping location tracking due to commute end.")
         locationWrangler.stopTracking(save: true)
     }
@@ -75,8 +84,7 @@ extension AppManager: CommutesViewControllerEventHandler {
 
     func commutesViewController(_ vc: CommutesViewController, didDelete commute: Commute) {
         commuteManager.delete(commute)
-        
-        commuteViewController.commutes = commuteManager.fetchCommutes()
+        updateCommutes()
     }
     
     func startCommute(for vc: CommutesViewController) {

--- a/CommuteLog/CommuteManager.swift
+++ b/CommuteLog/CommuteManager.swift
@@ -99,8 +99,10 @@ class CommuteManager: NSObject {
         return store.delete(commute)
     }
 
-    func fetchCommutes() -> [Commute] {
-        return store.loadCommutes().values.sorted(by: { $0.start > $1.start })
+    func fetchCommutes(for schedule: CommuteSchedule = CommuteSchedule(hours: 0..<24), ascending: Bool = false) -> [Commute] {
+        return store.loadCommutes().values
+            .filter({ schedule.contains($0.start) })
+            .sorted(by: { ($0.start < $1.start) == ascending })
     }
 }
 

--- a/CommuteLog/Table+Section.swift
+++ b/CommuteLog/Table+Section.swift
@@ -1,0 +1,54 @@
+//
+//  Table+Section.swift
+//  CommuteLog
+//
+//  Created by James Pamplona on 11/2/18.
+//  Copyright © 2018 Aranasaurus. All rights reserved.
+//
+
+import Foundation
+
+struct Section<Item> {
+    let title: String?
+    let hideIfEmpty: Bool
+    let items: [Item]
+
+    init(title: String? = nil, hideIfEmpty: Bool = true, items: [Item] = []) {
+        self.title = title
+        self.hideIfEmpty = hideIfEmpty
+        self.items = items
+    }
+
+    init(title: String? = nil, hideIfEmpty: Bool = true, items: Item...) {
+        self.init(title: title, hideIfEmpty: hideIfEmpty, items: items)
+    }
+
+    init(_ title: String?, hideIfEmpty: Bool = true, with getItems: () -> [Item] ) {
+        self.init(title: title, hideIfEmpty: hideIfEmpty, items: getItems())
+    }
+}
+
+struct Table<Item> {
+    let sections: [Section<Item>]
+    var allItems: [Item] {
+        return sections.reduce([Item]()) {
+            $0 + $1.items
+        }
+    }
+
+    init(sections: [Section<Item>]) {
+        self.sections = Array(sections.filter { !($0.hideIfEmpty && $0.items.isEmpty) })
+    }
+
+    init(_ sections: Section<Item>...) {
+        self.init(sections: sections)
+    }
+
+    init(with getSections: () -> [Section<Item>]) {
+        self.init(sections: getSections())
+    }
+
+    subscript(_ sectionIndex: Int) -> Section<Item> {
+        return sections[sectionIndex]
+    }
+}


### PR DESCRIPTION
Resolve #13 

This might be overkill with the Table+Section stuff. What I like about it though, is it lets you play around with different section configurations in one place without having to touch all the different places in the `CommutesViewController`
Also, I'm just splitting the commutes based on whether they start before noon or after noon. I had originally used the exit windows from the commuteManager for work and home, but this made it so that if you started a commute outside of those times, it wouldn't show up in the list. 
Another possibility would be "To Work", "Home", and "Other".
Or sort them based on location rather than time windows.